### PR TITLE
Implement capsule gRPC service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # cat
-cat project, core logic of memory's capsule 
+
+cat is a small gRPC service for reading memory capsules.
+
+It exposes a `Cat` gRPC service with a `GetCapsule` method and returns capsule data by ID. The current implementation uses a small in-memory store, which keeps the service simple while the API contract is being shaped.
+
+## Run
+
+```sh
+go run .
+```
+
+The gRPC server listens on port `50051`.
+
+## API
+
+```proto
+service Cat {
+  rpc GetCapsule(GetCapsuleRequest) returns (GetCapsuleResponce);
+}
+```
+
+## Development
+
+Regenerate protobuf files:
+
+```sh
+make proto
+```
+
+Run checks:
+
+```sh
+go test ./...
+```

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -2,25 +2,45 @@ package api
 
 import (
 	"context"
-	grpc "github.com/Includeoyasi/cat/pkg/cat"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"log"
 	"time"
+
+	catpb "github.com/Includeoyasi/cat/pkg/cat"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type GrpcServer struct {
-	grpc.UnimplementedCatServer
+	catpb.UnimplementedCatServer
+	capsules map[int32]*catpb.Capsule
 }
 
-func GetCapsule(ctx context.Context, in *grpc.GetCapsuleRequest) (*grpc.GetCapsuleResponce, error) {
-	log.Printf("Capsule ID: %s", in.GetId())
-	return &grpc.GetCapsuleResponce{
-		Result: &grpc.Capsule{
-			Id:        505,
-			Author:    "Dimka",
-			Text:      "Hello world",
-			Label:     "test",
-			CreatedAt: timestamppb.New(time.Now()),
+func NewGrpcServer() GrpcServer {
+	createdAt := timestamppb.New(time.Now())
+
+	return GrpcServer{
+		capsules: map[int32]*catpb.Capsule{
+			1: {
+				Id:        1,
+				Author:    "Includeoyasi",
+				Text:      "First memory capsule",
+				Label:     "demo",
+				CreatedAt: createdAt,
+			},
 		},
+	}
+}
+
+func (s GrpcServer) GetCapsule(ctx context.Context, in *catpb.GetCapsuleRequest) (*catpb.GetCapsuleResponce, error) {
+	log.Printf("Capsule ID: %d", in.GetId())
+
+	capsule, ok := s.capsules[in.GetId()]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "capsule %d not found", in.GetId())
+	}
+
+	return &catpb.GetCapsuleResponce{
+		Result: capsule,
 	}, nil
 }

--- a/api/grpc_server_test.go
+++ b/api/grpc_server_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	catpb "github.com/Includeoyasi/cat/pkg/cat"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetCapsuleReturnsSeededCapsule(t *testing.T) {
+	server := NewGrpcServer()
+
+	res, err := server.GetCapsule(context.Background(), &catpb.GetCapsuleRequest{Id: 1})
+	if err != nil {
+		t.Fatalf("get capsule: %v", err)
+	}
+
+	if res.GetResult().GetId() != 1 {
+		t.Fatalf("unexpected capsule id: got %d, want 1", res.GetResult().GetId())
+	}
+}
+
+func TestGetCapsuleReturnsNotFound(t *testing.T) {
+	server := NewGrpcServer()
+
+	_, err := server.GetCapsule(context.Background(), &catpb.GetCapsuleRequest{Id: 404})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("unexpected error code: got %v, want %v", status.Code(err), codes.NotFound)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	server := grpc.NewServer()
 	reflection.Register(server)
-	proto.RegisterCatServer(server, api.GrpcServer{})
+	proto.RegisterCatServer(server, api.NewGrpcServer())
 
 	log.Printf("server listening at: %s", lst.Addr())
 


### PR DESCRIPTION
## Summary
- implement the Cat gRPC GetCapsule method
- add an in-memory capsule store and not found response
- document usage and add service tests

## Tests
- GOCACHE=/private/tmp/cat-go-cache GOMODCACHE=/private/tmp/go-mod-cache go test ./...